### PR TITLE
Refactor masking logic and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+coverage/
+.DS_Store

--- a/__tests__/mask-utils.test.js
+++ b/__tests__/mask-utils.test.js
@@ -1,0 +1,17 @@
+const { maskText } = require('../mask-utils');
+
+describe('maskText', () => {
+  test('masks currency values', () => {
+    expect(maskText('$123.45')).toBe('•••');
+    expect(maskText('Total: €100')).toBe('Total: •••');
+  });
+
+  test('masks plain numbers and percentages', () => {
+    expect(maskText('Balance 1000')).toBe('Balance •••');
+    expect(maskText('5% increase')).toBe('••• increase');
+  });
+
+  test('returns original text when no numbers', () => {
+    expect(maskText('hello world')).toBe('hello world');
+  });
+});

--- a/content.js
+++ b/content.js
@@ -365,52 +365,22 @@ function maskTableData() {
 // Process all text inside an element directly
 function processTextInElement(element) {
   if (!element || !shouldProcessNode(element)) return;
-  
-  // Apply the same regex from processTextNode function
-  const basicNumberRegex = /(\$|€|£|¥)\s*\d+(?:[.,]\d+)*(?:\.\d+)?|\b\d+(?:[.,]\d+)*(?:\.\d+)?(?:\s*%)?/g;
-  const digitSequenceRegex = /\d+/g;
-  
-  // Handle immediate text in this element (not in children)
+
+  // Handle immediate text nodes
   for (const node of element.childNodes) {
     if (node.nodeType === Node.TEXT_NODE) {
-      let text = node.textContent;
-      let hasNumbers = false;
-      
-      if (basicNumberRegex.test(text)) {
-        text = text.replace(basicNumberRegex, '•••');
-        hasNumbers = true;
-      }
-      
-      // If still contains digits, use the more aggressive approach
-      if (/\d/.test(text)) {
-        text = text.replace(digitSequenceRegex, '•••');
-        hasNumbers = true;
-      }
-      
-      if (hasNumbers) {
-        node.textContent = text;
+      const masked = maskText(node.textContent);
+      if (masked !== node.textContent) {
+        node.textContent = masked;
       }
     }
   }
-  
-  // In case the element has no child text nodes but has direct textContent
+
+  // Process direct text content
   if (element.childNodes.length === 0 && element.textContent.trim() !== '') {
-    let text = element.textContent;
-    let hasNumbers = false;
-    
-    if (basicNumberRegex.test(text)) {
-      text = text.replace(basicNumberRegex, '•••');
-      hasNumbers = true;
-    }
-    
-    // If still contains digits, use the more aggressive approach
-    if (/\d/.test(text)) {
-      text = text.replace(digitSequenceRegex, '•••');
-      hasNumbers = true;
-    }
-    
-    if (hasNumbers) {
-      element.textContent = text;
+    const masked = maskText(element.textContent);
+    if (masked !== element.textContent) {
+      element.textContent = masked;
     }
   }
 }
@@ -639,35 +609,15 @@ function processNode(node) {
 // Process a text node to mask numbers
 function processTextNode(node) {
   if (!node || !node.textContent) return;
-  
+
   // Skip if parent element should not be processed
   if (node.parentElement && !shouldProcessNode(node.parentElement)) {
     return;
   }
-  
-  // First check: Basic number formats with currency symbols and decimals
-  const basicNumberRegex = /(\$|€|£|¥)\s*\d+(?:[.,]\d+)*(?:\.\d+)?|\b\d+(?:[.,]\d+)*(?:\.\d+)?(?:\s*%)?/g;
-  
-  // Second check: Any standalone digit sequence (very aggressive)
-  const digitSequenceRegex = /\d+/g;
-  
-  // Replace all occurrences with the mask
-  let text = node.textContent;
-  let hasNumbers = false;
-  
-  if (basicNumberRegex.test(text)) {
-    text = text.replace(basicNumberRegex, '•••');
-    hasNumbers = true;
-  }
-  
-  // If still contains digits, use the more aggressive approach
-  if (/\d/.test(text)) {
-    text = text.replace(digitSequenceRegex, '•••');
-    hasNumbers = true;
-  }
-  
-  if (hasNumbers) {
-    node.textContent = text;
+
+  const masked = maskText(node.textContent);
+  if (masked !== node.textContent) {
+    node.textContent = masked;
   }
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
   "content_scripts": [
     {
       "matches": ["*://app.monarchmoney.com/*"],
-      "js": ["content.js"],
+      "js": ["mask-utils.js", "content.js"],
       "run_at": "document_end"
     }
   ],

--- a/mask-utils.js
+++ b/mask-utils.js
@@ -1,0 +1,32 @@
+// Utility functions for masking numeric content
+// These functions are global when loaded in the extension but can also be
+// imported in Node for testing.
+
+/**
+ * Regex for numbers and common currency formats.
+ * Matches strings like "$12.34", "100" or "99%".
+ */
+const BASIC_NUMBER_REGEX = /(\$|€|£|¥)\s*\d+(?:[.,]\d+)*(?:\.\d+)?|\b\d+(?:[.,]\d+)*(?:\.\d+)?(?:\s*%)?/g;
+
+/** Regex for any sequence of digits. */
+const DIGIT_SEQUENCE_REGEX = /\d+/g;
+
+/**
+ * Mask numeric values in the provided text using bullet characters.
+ *
+ * @param {string} text - Raw text that may contain numeric values.
+ * @returns {string} - Masked text with numbers replaced by "•••".
+ */
+function maskText(text) {
+  if (!text) return text;
+  let result = text.replace(BASIC_NUMBER_REGEX, '•••');
+  if (/\d/.test(result)) {
+    result = result.replace(DIGIT_SEQUENCE_REGEX, '•••');
+  }
+  return result;
+}
+
+// Export for tests when running under Node.
+if (typeof module !== 'undefined') {
+  module.exports = { maskText, BASIC_NUMBER_REGEX, DIGIT_SEQUENCE_REGEX };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "monarchmask",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}


### PR DESCRIPTION
## Summary
- move regex masking into new `mask-utils.js`
- use helper in content script for clarity
- update manifest to load new script
- add Jest-based test for masking helper
- document npm setup with `package.json`

## Testing
- `npm test` *(fails: jest not found)*